### PR TITLE
Applying locale adjustments to chromium

### DIFF
--- a/src/modules/fullpageos/config
+++ b/src/modules/fullpageos/config
@@ -3,9 +3,15 @@
 [ -n "$FULLPAGEOS_OVERRIDE_TIMEZONE" ] || FULLPAGEOS_OVERRIDE_TIMEZONE=default
 
 #override locale, otherwise use image locale
-# Run locale -a to get a list of the locale names suitable for use in environment variables. Note that the spellings are different from the ones presented in the dpkg-reconfigure list.
+# Run locale -a to get a list of the locale names suitable for use in environment
+# variables. Note that the spellings are different from the ones presented in the
+# dpkg-reconfigure list.
 # More information at https://wiki.debian.org/Locale#Standard
-[ -n "$FULLPAGEOS_OVERRIDE_LOCALE" ] || FULLPAGEOS_OVERRIDE_LOCALE=default
+# - FULLPAGEOS_OVERRIDE_LOCALE: locale identifier like 'en_GB.UTF-8'
+# - FULLPAGEOS_OVERRIDE_LOCALE_GEN: locale identifier plus encoding, like required
+#   by the locale-gen tool. Example: 'en_GB.UTF-8 UTF-8'
+[ -n "$FULLPAGEOS_OVERRIDE_LOCALE" ] || FULLPAGEOS_OVERRIDE_LOCALE_GEN=default
+[ -n "$FULLPAGEOS_OVERRIDE_LOCALE_GEN" ] || FULLPAGEOS_OVERRIDE_LOCALE_GEN="en_GB.UTF-8 UTF-8"
 
 #override password, otherwise use image default
 [ -n "$FULLPAGEOS_OVERRIDE_PASSWORD" ] || FULLPAGEOS_OVERRIDE_PASSWORD=default

--- a/src/modules/fullpageos/start_chroot_script
+++ b/src/modules/fullpageos/start_chroot_script
@@ -78,7 +78,8 @@ fi
 if [ "$FULLPAGEOS_OVERRIDE_LOCALE" != "default" ]
 then
     apt-get install -y locales-all
-    echo "$FULLPAGEOS_OVERRIDE_LOCALE_GEN" >> /etc/locale.gen
+    # uncomment the locale we want to generate
+    sed -i "/$FULLPAGEOS_OVERRIDE_LOCALE_GEN/s/^#//" /etc/locale.gen
     locale-gen
     update-locale LANG="$FULLPAGEOS_OVERRIDE_LOCALE"
 

--- a/src/modules/fullpageos/start_chroot_script
+++ b/src/modules/fullpageos/start_chroot_script
@@ -80,12 +80,9 @@ then
     apt-get install -y locales-all
     # uncomment the locale we want to generate
     sed -i "/$FULLPAGEOS_OVERRIDE_LOCALE_GEN/s/^#//" /etc/locale.gen
+    # generate locale(s)
     locale-gen
-    update-locale LANG="$FULLPAGEOS_OVERRIDE_LOCALE"
-
-    # append locale settings in profile
-    echo "" >> /home/pi/.profile
-    echo "export LANG=$FULLPAGEOS_OVERRIDE_LOCALE" >> /home/pi/.profile
+    update-locale $FULLPAGEOS_OVERRIDE_LOCALE
 fi
 
 #override password

--- a/src/modules/fullpageos/start_chroot_script
+++ b/src/modules/fullpageos/start_chroot_script
@@ -81,6 +81,10 @@ then
     echo "$FULLPAGEOS_OVERRIDE_LOCALE_GEN" > /etc/locale.gen
     locale-gen
     update-locale LANG="$FULLPAGEOS_OVERRIDE_LOCALE"
+
+    # append locale settings in profile
+    echo "" >> /home/pi/profile
+    echo "export LANG=$FULLPAGEOS_OVERRIDE_LOCALE" >> /home/pi/profile
 fi
 
 #override password

--- a/src/modules/fullpageos/start_chroot_script
+++ b/src/modules/fullpageos/start_chroot_script
@@ -19,7 +19,7 @@ apt-get remove -y --purge scratch squeak-plugins-scratch squeak-vm wolfram-engin
 apt-get autoremove -y
 
 #apt-get tools
-apt-get -y --force-yes install python2.7 git screen checkinstall avahi-daemon libavahi-compat-libdnssd1 xterm locales-all
+apt-get -y --force-yes install python2.7 git screen checkinstall avahi-daemon libavahi-compat-libdnssd1 xterm
 
 if [ "$FULLPAGEOS_INCLUDE_CHROMIUM" == "yes" ]
 then
@@ -77,7 +77,7 @@ fi
 #override locale
 if [ "$FULLPAGEOS_OVERRIDE_LOCALE" != "default" ]
 then
-    sed -i '/^#.* '"$FULLPAGEOS_OVERRIDE_LOCALE"' /s/^# //' /etc/locale.gen
+    echo "$FULLPAGEOS_OVERRIDE_LOCALE_GEN" > /etc/locale.gen
     locale-gen
     update-locale LANG="$FULLPAGEOS_OVERRIDE_LOCALE"
 fi

--- a/src/modules/fullpageos/start_chroot_script
+++ b/src/modules/fullpageos/start_chroot_script
@@ -78,8 +78,8 @@ fi
 if [ "$FULLPAGEOS_OVERRIDE_LOCALE" != "default" ]
 then
     apt-get install -y locales-all
-    #echo "$FULLPAGEOS_OVERRIDE_LOCALE_GEN" > /etc/locale.gen
-    #locale-gen
+    echo "$FULLPAGEOS_OVERRIDE_LOCALE_GEN" >> /etc/locale.gen
+    locale-gen
     update-locale LANG="$FULLPAGEOS_OVERRIDE_LOCALE"
 
     # append locale settings in profile

--- a/src/modules/fullpageos/start_chroot_script
+++ b/src/modules/fullpageos/start_chroot_script
@@ -19,7 +19,7 @@ apt-get remove -y --purge scratch squeak-plugins-scratch squeak-vm wolfram-engin
 apt-get autoremove -y
 
 #apt-get tools
-apt-get -y --force-yes install python2.7 git screen checkinstall avahi-daemon libavahi-compat-libdnssd1 xterm
+apt-get -y --force-yes install python2.7 git screen checkinstall avahi-daemon libavahi-compat-libdnssd1 xterm locales-all
 
 if [ "$FULLPAGEOS_INCLUDE_CHROMIUM" == "yes" ]
 then

--- a/src/modules/fullpageos/start_chroot_script
+++ b/src/modules/fullpageos/start_chroot_script
@@ -55,12 +55,12 @@ then
         fi
         #Set Welcome screen
         if [ "$FULLPAGEOS_INCLUDE_WELCOME" == "yes" ]
-        then        
+        then
             gitclone FULLPAGEOS_WELCOME_REPO welcome
             chown -R www-data:www-data welcome
         fi
     popd
-    
+
     echo "enabled" > /boot/check_for_httpd
 else
     echo "disabled" > /boot/check_for_httpd

--- a/src/modules/fullpageos/start_chroot_script
+++ b/src/modules/fullpageos/start_chroot_script
@@ -77,6 +77,7 @@ fi
 #override locale
 if [ "$FULLPAGEOS_OVERRIDE_LOCALE" != "default" ]
 then
+    apt-get install -y locales-all
     echo "$FULLPAGEOS_OVERRIDE_LOCALE_GEN" > /etc/locale.gen
     locale-gen
     update-locale LANG="$FULLPAGEOS_OVERRIDE_LOCALE"

--- a/src/modules/fullpageos/start_chroot_script
+++ b/src/modules/fullpageos/start_chroot_script
@@ -78,13 +78,13 @@ fi
 if [ "$FULLPAGEOS_OVERRIDE_LOCALE" != "default" ]
 then
     apt-get install -y locales-all
-    echo "$FULLPAGEOS_OVERRIDE_LOCALE_GEN" > /etc/locale.gen
-    locale-gen
+    #echo "$FULLPAGEOS_OVERRIDE_LOCALE_GEN" > /etc/locale.gen
+    #locale-gen
     update-locale LANG="$FULLPAGEOS_OVERRIDE_LOCALE"
 
     # append locale settings in profile
-    echo "" >> /home/pi/profile
-    echo "export LANG=$FULLPAGEOS_OVERRIDE_LOCALE" >> /home/pi/profile
+    echo "" >> /home/pi/.profile
+    echo "export LANG=$FULLPAGEOS_OVERRIDE_LOCALE" >> /home/pi/.profile
 fi
 
 #override password


### PR DESCRIPTION
Part of an attempt to help avoid Chromium showing a translate tool for non-english web content, as described in https://github.com/guysoft/FullPageOS/issues/7

This adds the package `locales-all` to enable installing of a locale matching the content language to be displayed in Chromium.

We then attempt to influence the `LANG` environment variable by exporting it in `/home/pi/.profile`, but the file actually doesn't get modified (or it's overwritten later). How can we add our one line

    export LANG=${FULLPAGEOS_OVERRIDE_LOCALE}

with replaced to `${FULLPAGEOS_OVERRIDE_LOCALE}` to `/home/pi/.profile`?